### PR TITLE
Add goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+before:
+  hooks:
+    - go mod download
+builds:
+- main: main.go
+  binary: prometheus-statuspage-pusher
+  goos:
+    - linux
+  goarch:
+    - amd64
+  env:
+  - CGO_ENABLED=0
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/balena-io/prometheus-statuspage-pusher
 go 1.14
 
 require (
-	github.com/go-kit/kit v0.10.0 // indirect
-	github.com/prometheus/client_golang v1.5.1 // indirect
+	github.com/ghodss/yaml v1.0.0
+	github.com/go-kit/kit v0.10.0
+	github.com/prometheus/client_golang v1.5.1
+	github.com/prometheus/common v0.9.1
 )


### PR DESCRIPTION
- Add `.goreleaser.yml` config to streamline building and storing binary releases on GitHub